### PR TITLE
Allow for earlier versions of pyyaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ python = ">=3.8.1,<4.0"
 mkdocs = "^1.4.3"
 igittigitt = "^2.1.2"
 schema = "^0.7.5"
-pyyaml = "^6.0"
+pyyaml = ">=5,<7"
 pyyaml-env-tag = "^0.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## 💌 Description

Requiring pyyaml>=6 makes it impossible to install this tool if other dependencies in your project, such as awscli, require pyyaml<6.

Giving this dependency more flexibility will allow me to use it in my project. I assume it will not break the behavior of the tool. Please let me know if I'm wrong or if this project is directly depending on features only available in Pyyaml 6.

Thanks for making this!