### PR TITLE
Code of Conduct location in Github Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -98,7 +98,7 @@ body:
     id: terms
     attributes:
       label: 📜 Code of Conduct
-      description: By submitting this issue, you agree to follow our [`Code of Conduct`](https://github.com/DariuszPorowski/mkdocs-file-filter-plugin/blob/main/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [`Code of Conduct`](https://github.com/DariuszPorowski/mkdocs-file-filter-plugin/blob/main/.github/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct.
           required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -44,7 +44,7 @@ body:
     id: terms
     attributes:
       label: 📜 Code of Conduct
-      description: By submitting this issue, you agree to follow our [`Code of Conduct`](https://github.com/DariuszPorowski/mkdocs-file-filter-plugin/blob/main/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [`Code of Conduct`](https://github.com/DariuszPorowski/mkdocs-file-filter-plugin/blob/main/.github/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct.
           required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -38,7 +38,7 @@ body:
     id: terms
     attributes:
       label: 📜 Code of Conduct
-      description: By submitting this issue, you agree to follow our [`Code of Conduct`](https://github.com/DariuszPorowski/mkdocs-file-filter-plugin/blob/main/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [`Code of Conduct`](https://github.com/DariuszPorowski/mkdocs-file-filter-plugin/blob/main/.github/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct.
           required: true


### PR DESCRIPTION
## 💌 Description

The location of the code of conduct apparently changed. I am not sure if it is supposed to live in the `.github` subdirectory, but I offer this PR to bring the issue templates in line with the actual location.

## 🏗️ Type of change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🚨 Security fix
- [ ] ⬆️ Dependencies update

(Neither does apply.)

## ✅ Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`Code of Conduct`](https://github.com/DariuszPorowski/mkdocs-file-filter-plugin/blob/main/.github/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`Contributing`](https://github.com/DariuszPorowski/mkdocs-file-filter-plugin/blob/main/.github/CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.

(the latter two do not apply in this case)